### PR TITLE
Replace bigint with bignum.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -7,7 +7,7 @@
  */
 
 var printable = require('./printable.js');
-var bigint = require('bigint');
+var bignum = require('bignum');
 
 var field_types = {
     DMAP_UNKNOWN: 0,
@@ -305,14 +305,14 @@ var parser = {
     },
 
     dmap_read_64: function(buffer, iterator) {
-        return this.to_int32(bigint(buffer.readInt8(0)).and(0xff).shiftLeft(56)) |
-            this.to_int32(bigint(buffer.readInt8(1)).and(0xff).shiftLeft(48)) |
-            this.to_int32(bigint(buffer.readInt8(2)).and(0xff).shiftLeft(40)) |
-            this.to_int32(bigint(buffer.readInt8(3)).and(0xff).shiftLeft(32)) |
-            this.to_int32(bigint(buffer.readInt8(4)).and(0xff).shiftLeft(24)) |
-            this.to_int32(bigint(buffer.readInt8(5)).and(0xff).shiftLeft(16)) |
-            this.to_int32(bigint(buffer.readInt8(6)).and(0xff).shiftLeft(8)) |
-            this.to_int32(bigint(buffer.readInt8(7)).and(0xff));
+        return this.to_int32(bignum(buffer.readInt8(0)).and(0xff).shiftLeft(56)) |
+            this.to_int32(bignum(buffer.readInt8(1)).and(0xff).shiftLeft(48)) |
+            this.to_int32(bignum(buffer.readInt8(2)).and(0xff).shiftLeft(40)) |
+            this.to_int32(bignum(buffer.readInt8(3)).and(0xff).shiftLeft(32)) |
+            this.to_int32(bignum(buffer.readInt8(4)).and(0xff).shiftLeft(24)) |
+            this.to_int32(bignum(buffer.readInt8(5)).and(0xff).shiftLeft(16)) |
+            this.to_int32(bignum(buffer.readInt8(6)).and(0xff).shiftLeft(8)) |
+            this.to_int32(bignum(buffer.readInt8(7)).and(0xff));
     },
 
     dmap_read_32: function(buffer, iterator) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Jeffrey Muller <jeffrey.muller92@gmail.com>",
     "contributors": [],
     "dependencies": {
-        "bigint": ">=0.4.2",
+        "bignum": ">=0.9.0",
         "request": ">=2.33.0"
     },
     "repository": {


### PR DESCRIPTION
Using `bigint` requires a dependency (libgmp) which isn’t necessarily available on all machines (it’s not on mine) but `bignum` is API-compatible and uses OpenSSL (which is required by node itself and as such is always available). 

I went to run the tests to verify the fix, but I don’t know how to run them!
